### PR TITLE
Changed "Int" to "лист"

### DIFF
--- a/extensions.md
+++ b/extensions.md
@@ -23,7 +23,7 @@ The following adds a `swap` function to `MutableList<Int>`:-->
 
 ``` kotlin
 fun MutableList<Int>.swap(index1: Int, index2: Int) {
-    val tmp = this[index1] // 'this' даёт ссылку на Int
+    val tmp = this[index1] // 'this' даёт ссылку на лист
     this[index1] = this[index2]
     this[index2] = tmp
 }


### PR DESCRIPTION
From https://kotlinlang.org/docs/reference/extensions.html 

Original:

fun MutableList<Int>.swap(index1: Int, index2: Int) {
    val tmp = this[index1] // 'this' corresponds to the list
    this[index1] = this[index2]
    this[index2] = tmp
}