### PR TITLE
Update link to menu file / Обновление ссылки к файлу меню

### DIFF
--- a/add-new-article.md
+++ b/add-new-article.md
@@ -9,7 +9,7 @@ url: https://kotlinlang.ru/docs/reference/add-new-article.html
 
 Для создания новой статьи нужно выполнить два действия:
 
-* Добавить пункт меню в файл `menu.json`. То есть отредактировать `menu.json`  https://github.com/phplego/kotlin.su/edit/master/menu.json
+* Добавить пункт меню в файл `menu.json`. То есть отредактировать `menu.json` https://github.com/phplego/kotlinlang.ru/blob/master/MENU.json 
 * Создать файл с соответствующим именем `<article-id>.md`. Или скопировать соответствующий файл из [английской документации](https://github.com/JetBrains/kotlin-web-site/tree/master/pages/docs/reference).
 
 Оригинальные тексты документации на английском находятся тут:


### PR DESCRIPTION
Old link did not lead to the configuration file MENU.json
Старая ссылка не вела на страницу конфигурационного файла.