### PR TITLE
Update inline-functions.md

### DIFF
--- a/inline-functions.md
+++ b/inline-functions.md
@@ -47,7 +47,7 @@ finally {
 Чтобы заставить компилятор поступить именно так, нам необходимо отметить функцию `lock` модификатором `inline`:
 
 ``` kotlin
-inline fun lock<T>(lock: Lock, body: () -> T): T {
+inline fun <T> lock(lock: Lock, body: () -> T): T {
     // ...
 }
 ```


### PR DESCRIPTION
ошибка в примере: в неправильном месте указан тип
Type parameters must be placed before the name of the function