### PR TITLE
обновление текста

### DIFF
--- a/object-declarations.md
+++ b/object-declarations.md
@@ -66,7 +66,7 @@ print(adHoc.x + adHoc.y)
 
 <!-- Just like Java's anonymous inner classes, code in object expressions can access variables from the enclosing scope. -->
 <!-- (Unlike Java, this is not restricted to final variables.) -->
-Код внутри объявленного объекта может обращаться к переменным за скобками так же, как вложенные анонимные классы в <b>Java</b>
+Код внутри объявленного объекта может обращаться к переменным за скобками
 
 ```kotlin
 fun countClicks(window: JComponent) {


### PR DESCRIPTION
В англ версии сказано
The code in object expressions can access variables from the enclosing scope.

Здесь перевод
Код внутри объявленного объекта может обращаться к переменным за скобками так же, как вложенные анонимные классы в <b>Java</b>
текст "так же, как вложенные анонимные классы в <b>Java</b>" неправильный текст, точнее он может ввести человека в заблуждение
так как в java как раз можно обращаться только к final переменным или переменным которые не изменяют свое значение и компилятор знает что они введут себя как final
в kotlin же ты можешь обращаться к любым переменным, из-за того что под капотом для каждый переменной создается класс-обертка