### PR TITLE
Add missing bullet list

### DIFF
--- a/coding-conventions.md
+++ b/coding-conventions.md
@@ -170,7 +170,7 @@ or use camel case (`org.example.myProject`). -->
 либо просто объедените их вместе, либо используйте при этом lowerCamelСase (`org.example.myProject`).
 
 <!-- * Names of classes and objects start with an uppercase letter and use camel case: -->
-Имена классов и объектов начинаются с заглавной буквы и используют UpperCamelCase.
+* Имена классов и объектов начинаются с заглавной буквы и используют UpperCamelCase.
 
 ```kotlin
 open class DeclarationProcessor { /*...*/ }


### PR DESCRIPTION
Original coding convention has bullet list under this sentence, localization does not.